### PR TITLE
Fix JSON error in MTCNN notebook

### DIFF
--- a/FaceSwap_GAN_v2_test_video_MTCNN.ipynb
+++ b/FaceSwap_GAN_v2_test_video_MTCNN.ipynb
@@ -580,7 +580,7 @@
     "    result = (result_a/255 * result_bgr + (1 - result_a/255) * ((ae_input + 1) * 255 / 2)).astype('uint8')\n",
     "    if use_color_correction:\n",
     "        result = color_hist_match(result, roi_image)\n",
-    "    result = cv2.cvtColor(result.astype("uint8"), cv2.COLOR_BGR2RGB)\n",
+    "    result = cv2.cvtColor(result.astype('uint8'), cv2.COLOR_BGR2RGB)\n",
     "    result = cv2.resize(result, (roi_size[1],roi_size[0]))\n",
     "    result_a_clear = np.expand_dims(cv2.resize(result_a_clear, (roi_size[1],roi_size[0])), axis=2)\n",
     "    return result, result_a_clear\n",


### PR DESCRIPTION
`"uint8"` with the double quotes breaks the MTCNN notebook since it becomes invalid JSON.

Quick fix to replace it with single quotes to get it to open properly again in Jupyter.