### PR TITLE
Downgraded TF and Keras for library issues

### DIFF
--- a/colab_demo/faceswap-GAN_colab_demo.ipynb
+++ b/colab_demo/faceswap-GAN_colab_demo.ipynb
@@ -279,6 +279,8 @@
    "source": [
     "%%capture\n",
     "!pip install moviepy\n",
+    "!pip uninstall -y keras\n",
+    "!pip install keras==2.1.5\n",
     "!pip install keras_vggface\n",
     "import imageio\n",
     "imageio.plugins.ffmpeg.download()"
@@ -405,6 +407,7 @@
    "source": [
     "from keras.layers import *\n",
     "import keras.backend as K\n",
+    "%tensorflow_version 1.x \n"
     "import tensorflow as tf"
    ]
   },


### PR DESCRIPTION
Colab in the year 2020 have TensorFlow 2.0 as default and Keras with a higher version
This caused some function call errors in the execution.
So downgraded to instantly run the Notebook